### PR TITLE
Feature/html slide lede

### DIFF
--- a/viewshare/templates/front_page.html
+++ b/viewshare/templates/front_page.html
@@ -39,7 +39,7 @@
       {% endif %}
       </a>
       <div class="caption">
-        <p>{{ exhibit.custom_title }}</p>
+        <p>{{ exhibit.custom_title|safe }}</p>
       </div>
     </div><!-- /.slide -->
   {% endfor %}


### PR DESCRIPTION
Hi @dfeeney,

It came up during a meeting yesterday that admins would like to link to pages other than the exhibit in the slideshow text. This commit marks the slideshow's custom title as 'safe'.
