### PR TITLE
Editor page not displaying errors for mismatched datasource types

### DIFF
--- a/freemix/static/dataset/js/editor.js
+++ b/freemix/static/dataset/js/editor.js
@@ -66,7 +66,7 @@
         this.el.show();
         setTimeout($.proxy(this.render, this), 5000);
       } else if (data.hasOwnProperty('message')) {
-        if (data.message === 'No Data') {
+        if (data.message === 'No Data' || data.message === '') {
           window.location.reload(true);
         }
       }else {


### PR DESCRIPTION
Hi @dfeeney,

I believe I tracked down the issue we were having with asynchronous datasources not displaying their errors properly. To recreate the issue I did the following:
1. Go to the upload data screen
2. Select "From the Web" under "Simple Spreadsheets"
3. Enter the following URL: https://api.twitter.com/1/statuses/user_timeline.json?screen_name=ndiipp&count=20
4. Click upload

At this point the editor screen would hang. The problem is that Akara is failing and throwing a 500. Our front-end code was expecting Akara to set the response message to 'No Data'. When Akara throws a 500, no message is set. This commit considers this possibility and reloads the page to display an error message if it's encountered.
