### PR TITLE
Requirements update

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -15,12 +15,12 @@ django-uni-form==0.8.0
 httplib2==0.7.6
 
 #django-cms depends on the following
-django-reversion==1.7
+django-reversion==1.6.6
 django-classy-tags==0.4
 django-sekizai==0.7
 django-mptt==0.5.2
 html5lib==0.95
-django-cms==2.4.0.RC1
+django-cms==2.3.6
 
 # Piston is required by viewshare.apps.collection_catalog and uses the following
 django-piston==0.2.3


### PR DESCRIPTION
Hi @wamberg,

While setting up a new environment, it turns out that the version of 'elementtree' that our requirements reference has disappeared from pypi and causes the installation to fail.  This is only really used by django-cms, and it turns out that the newest version (which is unfortunately just a release candidate) removes the dependency.  I've audited the requirements and updated various libs to their latest versions.  Your review would be appreciated.
