### PR TITLE
redundant path in the uservoice url patterns

### DIFF
--- a/viewshare/apps/support/uservoice/urls.py
+++ b/viewshare/apps/support/uservoice/urls.py
@@ -1,11 +1,11 @@
 from django.conf.urls import url, patterns
 
 urlpatterns = patterns('',
-    url(r'^uservoice/options.js$',
+    url(r'^options.js$',
         'viewshare.apps.support.uservoice.views.uservoice_options',
         name='uservoice_options'),
 
-    url(r'^uservoice/login/$',
+    url(r'^login/$',
         'viewshare.apps.support.uservoice.views.login',
         name="uservoice_acct_login"),
 )


### PR DESCRIPTION
When deployed, the uservoice support urls should be mapped to the top level uservoice root.  This was being redundantly duplicated in the app level url pattern, resulting in /uservoice/uservoice/login/, for example.  This broke the single sign in integration.
