### PR TITLE
consistent behavior for the labelling of facets.

### DIFF
--- a/viewshare/apps/exhibit/static/freemix/js/display/facets/list.js
+++ b/viewshare/apps/exhibit/static/freemix/js/display/facets/list.js
@@ -5,7 +5,6 @@ define(["jquery",
 
     var config = {
         type:"list",
-        name: "List",
         expression:"",
         showMissing:true,
         sortDirection:"forward",

--- a/viewshare/apps/exhibit/static/freemix/js/display/facets/numeric.js
+++ b/viewshare/apps/exhibit/static/freemix/js/display/facets/numeric.js
@@ -4,8 +4,7 @@ define(["jquery",
         "use strict";
 
 
-        var config = {
-        name: "Range",
+    var config = {
         type:"NumericRange",
         interval:10
     };
@@ -15,7 +14,7 @@ define(["jquery",
         var result = $("<div data-ex-role='facet' data-ex-facet-class='NumericRange'  class='exhibit-facet'></div>");
         result.attr("data-ex-expression", config.expression);
         if (config.name && config.name.length > 0) {
-            result.attr("data-ex-facetLabel", config.name);
+            result.attr("data-ex-facet-label", config.name);
         }
         if (config.interval && config.interval > 0) {
             result.attr("data-ex-interval", config.interval);

--- a/viewshare/apps/exhibit/static/freemix/js/display/facets/slider.js
+++ b/viewshare/apps/exhibit/static/freemix/js/display/facets/slider.js
@@ -6,7 +6,6 @@ define(["jquery",
 
     var config = {
         type:"Slider",
-        name: "Slider",
         expression:"",
         height:"50px",
         histogram:true,
@@ -23,7 +22,7 @@ define(["jquery",
         result.attr("data-ex-histogram", config.histogram);
         result.attr("data-ex-horizontal", config.horizontal);
         if (config.name && config.name.length > 0) {
-            result.attr("data-ex-facet-abel", config.name);
+            result.attr("data-ex-facet-label", config.name);
         }
         return result;
     };

--- a/viewshare/apps/exhibit/static/freemix/js/display/facets/tagcloud.js
+++ b/viewshare/apps/exhibit/static/freemix/js/display/facets/tagcloud.js
@@ -19,7 +19,7 @@ define(["jquery",
         var result = $("<div data-ex-role='facet' data-ex-facet-class='Cloud'  class='exhibit-facet exhibit-cloudFacet'></div>");
         result.attr("data-ex-expression", config.expression);
         if (config.name && config.name.length > 0) {
-            result.attr("data-ex-facetLabel", config.name);
+            result.attr("data-ex-facet-label", config.name);
         }
         return result;
     };


### PR DESCRIPTION
By default, they will be blank, which in most cases displays the selected property label.  A custom label can still be defined.  The default label for the 'search' facet will remain as 'Search'.
