### PR TITLE
Replace jQuery calls in compatible with jQuery code

### DIFF
--- a/viewshare/static/viewshare/js/compatible.js
+++ b/viewshare/static/viewshare/js/compatible.js
@@ -4,17 +4,28 @@
 var Compatible = {};
 
 Compatible.checkBrowser = function() {
+    // Variables cribbed from jQuery 1.3.  Should be replaced by feature
+    // detection as user agent data is unreliable.
+    var userAgent = navigator.userAgent.toLowerCase();
+    var browser = {
+	version: (userAgent.match( /.+(?:rv|it|ra|ie)[\/: ]([\d.]+)/ ) || [0,'0'])[1],
+	safari: /webkit/.test( userAgent ),
+	opera: /opera/.test( userAgent ),
+	msie: /msie/.test( userAgent ) && !/opera/.test( userAgent ),
+	mozilla: /mozilla/.test( userAgent ) && !/(compatible|webkit)/.test( userAgent )
+    };
+    
     var compatible = false;
-    if ($.browser.mozilla) {
-	if (parseFloat($.browser.version) >= 1.8) {
+    if (browser.mozilla) {
+	if (parseFloat(browser.version) >= 1.8) {
 	    compatible = true;
 	}
-    } else if ($.browser.msie) {
-	if (parseInt($.browser.version) >= 7) {
+    } else if (browser.msie) {
+	if (parseInt(browser.version) >= 7) {
 	    compatible = true;
 	}
-    } else if ($.browser.safari) {
-	if (parseInt($.browser.version) >= 300) {
+    } else if (browser.safari) {
+	if (parseInt(browser.version) >= 300) {
 	    compatible = true;
 	}
     }


### PR DESCRIPTION
Quick fix to stop browser warnings about deprecated and now removed jQuery browser detection, by using the deprecated detection code.  As described in #63 .
