### PR TITLE
Replace deprecated jQuery methods with current equivalents

### DIFF
--- a/viewshare/apps/exhibit/static/freemix/js/layout/editor.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/editor.js
@@ -164,7 +164,7 @@ define(["jquery",
         $(".view-container", Freemix.getBuilder()).each(function() {
             var container = $(this).data("model");
             var selected = container.getSelected();
-            if (selected.size() == 0) {
+            if (selected.length == 0) {
                 selected = container.findWidget().find(".view-set>li:first")
             }
             selected.data("model").select();

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/logo.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/logo.js
@@ -18,7 +18,7 @@ define(["jquery", "handlebars", "display/facets/logo", "exhibit", "text!template
 
             if (config.src) {
                 var img = template.find("#facet-preview img");
-                img.load(function () {
+                img.on("load", function () {
                     var naturalWidth = img.get(0).naturalWidth;
                     if (!naturalWidth) {
                         naturalWidth = img.get(0).width * 2;

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
@@ -115,10 +115,10 @@ define(["jquery",
 
     BaseView.prototype.remove = function() {
         var container = this.getContainer();
-        if (container.find(".view-set>li.view").size() > 1) {
+        if (container.find(".view-set>li.view").length > 1) {
             this.findWidget().remove();
             var next = container.find(".view-set>li.view:first");
-            if (next.size() > 0) {
+            if (next.length > 0) {
                 next.data("model").select();
             } else {
                 container.find(".view-content").empty();

--- a/viewshare/static/share/js/share_dialog.js
+++ b/viewshare/static/share/js/share_dialog.js
@@ -40,7 +40,7 @@
         });
     }
 
-    $(".shared-key-url").live("click", function() {
+    $(".shared-key-url").on("click", function() {
         $(this).select();
     });
 

--- a/viewshare/static/share/js/shared_exhibit.js
+++ b/viewshare/static/share/js/shared_exhibit.js
@@ -1,7 +1,7 @@
 (function($) {
 
     $(document).ready(function() {
-        $(".shared-key-url").live("click", function() {
+        $(".shared-key-url").on("click", function() {
             $(this).select();
         });
     });

--- a/viewshare/static/support/js/base.js
+++ b/viewshare/static/support/js/base.js
@@ -1,12 +1,12 @@
 (function($) {
     function setup() {
         var root = $("div#support");
-        $("div#support .cancel-button").live('click', function() {
+        $("div#support .cancel-button").on('click', function() {
             root.hide();
             $(root.data("from") + ", #subnav").fadeIn();
         });
 
-        $("div#support .ticket-created").live('click', function() {
+        $("div#support .ticket-created").on('click', function() {
             root.hide();
             $(root.data("from") + ", #subnav").fadeIn();
         });

--- a/viewshare/static/support/js/load.js
+++ b/viewshare/static/support/js/load.js
@@ -96,12 +96,12 @@
 
         });
 
-        $("div#support .cancel-button").live('click', function() {
+        $("div#support .cancel-button").on('click', function() {
             root.hide();
             $("#load-error").fadeIn();
         });
 
-        $("div#support .ticket-created").live('click', function() {
+        $("div#support .ticket-created").on('click', function() {
             root.hide();
             $("#load-error").fadeIn();
         });

--- a/viewshare/static/viewshare/js/ui.js
+++ b/viewshare/static/viewshare/js/ui.js
@@ -4,7 +4,7 @@ $(document).ready(function(){
     $(".messages>li.error").addClass("ui-corner-all").addClass("ui-state-error");
     $(".messages>li").prepend("<a href='#' class='ui-icon ui-icon-closethick close-message'>&#160;</a> ")
     // clear warning messages
-    $('a.close-message').live('click',function(e) {
+    $('a.close-message').on('click',function(e) {
         var messages = $(this).closest(".messages");
         $(this).parent().slideUp();
         e.preventDefault();

--- a/viewshare/templates/base.html
+++ b/viewshare/templates/base.html
@@ -13,12 +13,7 @@
   {% block rss_feeds %}{% endblock %}
   <title>{% if site_name %}{{ site_name }} : {% endif %}{% block head_title %}{% endblock %}</title>
   {% block head_jquery %}
-  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
-  <script>
-    if (!window.jQuery) {
-      document.write('<script type="text/javascript" src="{{STATIC_PREFIX}}freemix/js/lib/jquery.js"><\/script>');
-    }
-  </script>
+  <script type="text/javascript" src="{{STATIC_PREFIX}}freemix/js/lib/jquery.js"></script>
   {% endblock %}
   {% block head_css %}{% endblock %}
   {% block head_data %}{% endblock %}


### PR DESCRIPTION
Comprised of `.size()` to `.length`, `.live()` to `.on()`, and load for events to `.on('load')`.  Also modifies base template to be rid of jQuery 1.7 remote load in favor of local Viewshare jQuery.
