### PR TITLE
ensure that any bubble overlays are closed when a view or facet is closed

### DIFF
--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/base.js
@@ -47,6 +47,10 @@ define(["jquery",
                             facet.findContainer().getDialog().modal("hide");
                             facet.refresh();
                         });
+                        facet.findContainer().getDialog().off("hidden").one("hidden", function(evt) {
+                            editor.destroy();
+                        });
+
                         return false;
                     }).end();
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/container.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/container.js
@@ -59,6 +59,10 @@ define(["jquery",
             container.addFacet(model);
         }.bind(this._dialog));
 
+        this._dialog.off("hidden").one("hidden", function(evt) {
+            editor.destroy();
+        });
+
     };
 
     return Container;

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
@@ -30,11 +30,11 @@ define(["jquery",
         this.setupEditor(config, template);
 
         template.find("#widget_save_button").off("click").click(function() {
-           model.config = config;
-           template.trigger("edit-widget");
+            model.config = config;
+            template.trigger("edit-widget");
 
-           model.findWidget().find("span.view-label").text(model.config.name);
-           model.select();
+            model.findWidget().find("span.view-label").text(model.config.name);
+            model.select();
            
         });
 
@@ -108,6 +108,11 @@ define(["jquery",
                 view.findContainer().getDialog().modal("hide");
                 view.select();
             });
+
+            view.findContainer().getDialog().off("hidden").one("hidden", function(evt) {
+                editor.destroy();
+            });
+
             return false;
         });
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/container.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/container.js
@@ -63,6 +63,10 @@ define(["jquery",
             container.addView(model);
         }.bind(this.getDialog()));
 
+        this.getDialog().off("hidden").one("hidden", function(evt) {
+            editor.destroy();
+        });
+
     };
 
     return Container;

--- a/viewshare/apps/exhibit/static/freemix/js/layout/widget_editor.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/widget_editor.js
@@ -81,8 +81,9 @@ function($,
     }
 
     WidgetEditor.prototype.destroy = function() {
-        this.element.find("ul.nav a").off("click");
 
+        this.element.find("ul.nav a").off("click");
+        this.model.resetPreview(this.element.find(".widget-preview-body"));
         this.element.empty();
     }
 

--- a/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/barchart-view.js
+++ b/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/barchart-view.js
@@ -172,6 +172,8 @@ define([
 
         this._plot = null;
 
+        $(document).trigger("closeBubbles.simileAjax");
+
         this._dispose();
     };
 

--- a/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/piechart-view.js
+++ b/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/piechart-view.js
@@ -169,6 +169,8 @@ define([
         this._sliceToItemIDs = null;
         this._plot = null;
 
+        $(document).trigger("closeBubbles.simileAjax");
+
         this._dispose();
     };
 

--- a/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/scatterplot-view.js
+++ b/viewshare/apps/exhibit/static/simile/exhibit/extensions/flot/scripts/scatterplot-view.js
@@ -234,6 +234,8 @@ define([
         this._plot = null;
         this._itemIDToPoint = null;
 
+        $(document).trigger("closeBubbles.simileAjax");
+
         this._dispose();
     };
 

--- a/viewshare/apps/exhibit/static/simile/exhibit/extensions/map/scripts/map-view.js
+++ b/viewshare/apps/exhibit/static/simile/exhibit/extensions/map/scripts/map-view.js
@@ -371,6 +371,8 @@ MapView.prototype.dispose = function() {
     this._dom.dispose();
     this._dom = null;
 
+    $(document).trigger("closeBubbles.simileAjax");
+
     this._dispose();
 };
 

--- a/viewshare/apps/exhibit/static/simile/exhibit/extensions/openlayers/scripts/openlayers-view.js
+++ b/viewshare/apps/exhibit/static/simile/exhibit/extensions/openlayers/scripts/openlayers-view.js
@@ -324,7 +324,9 @@ define([
     
         this._dom.dispose();
         this._dom = null;
-    
+
+        $(document).trigger("closeBubbles.simileAjax");
+
         this._dispose();
     };
 


### PR DESCRIPTION
This fixes an issue where views that can open bubble overlays (graph views, map, timeline) are closed or destroyed that those bubbles are destroyed as well.
