### PR TITLE
stop widget editor accordion event bubbling

### DIFF
--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/map.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/map.js
@@ -71,7 +71,9 @@ define(["jquery",
                 return false;
             });
 
-            edit.off("hide").on("hide", function() {
+            edit.off("hidden").on("hidden", function(evt) {
+                evt.preventDefault();
+                evt.stopPropagation();
                 root.empty();
             });
         });
@@ -98,7 +100,10 @@ define(["jquery",
             });
 
 
-            augment.off("hidden").on("hidden", function() {
+            augment.off("hidden").on("hidden", function(evt) {
+                evt.preventDefault();
+                evt.stopPropagation();
+
                 location_view.destroy();
             });
         });

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/timeline.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/timeline.js
@@ -67,7 +67,10 @@ define(["jquery",
                 return false;
             });
 
-            edit.off("hide").on("hide", function() {
+            edit.off("hidden").on("hidden", function(evt) {
+                evt.preventDefault();
+                evt.stopPropagation();
+
                 root.empty();
             });
         });
@@ -94,7 +97,10 @@ define(["jquery",
             });
 
 
-            augment.off("hidden").on("hidden", function() {
+            augment.off("hidden").on("hidden", function(evt) {
+                evt.preventDefault();
+                evt.stopPropagation();
+
                 date_view.destroy();
             });
         });


### PR DESCRIPTION
 'hidden' event  for the accordion in map and timeline editors was bubbling up to the modal, causing the widget editor to be destroyed when switching panes.
