### PR TITLE
fixes #125, and provides a more substantial framework for view/facet validation

### DIFF
--- a/viewshare/apps/exhibit/static/freemix/js/display/views/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/display/views/base.js
@@ -1,9 +1,8 @@
 define(["jquery",
         "freemix/js/widget",
         "display/lenses/registry",
-        "freemix/js/freemix",
         "freemix/js/exhibit_utilities"],
-    function ($, Widget, LensRegistry, Freemix) {
+    function ($, Widget, LensRegistry) {
     "use strict";
 
     var expression = function(property){return "." + property;};

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/base.js
@@ -14,7 +14,7 @@ define(["jquery",
     BaseFacet.prototype.refreshEvent = "refresh-preview.facet";
 
 
-    BaseFacet.prototype.facetClass = Exhibit.ListFacet;
+    BaseFacet.prototype.exhibitClass = Exhibit.ListFacet;
 
     BaseFacet.prototype.findContainer = function() {
         return this.findWidget().parents(".facet-container").data("model");
@@ -59,34 +59,9 @@ define(["jquery",
     BaseFacet.prototype.refresh = function() {
         this.findWidget().find(".facet-content").empty().append(this.generateExhibitHTML());
         var exhibit = Freemix.getBuilderExhibit();
-        this.facetClass.createFromDOM(this.findWidget().find(".facet-content div").get(0), null, exhibit.getUIContext());
+        this.exhibitClass.createFromDOM(this.findWidget().find(".facet-content div").get(0), null, exhibit.getUIContext());
     };
 
-    BaseFacet.prototype.updatePreview = function(target, config) {
-
-        config = config || this.config;
-        this.resetPreview(target);
-        var preview = this.generateExhibitHTML(config);
-        target.append(preview);
-        var exhibit = Freemix.getBuilderExhibit();
-
-        try {
-            target.data("preview", this.facetClass.createFromDOM(preview.get(0), null, exhibit.getUIContext()));
-        } catch(ex) {
-            target.empty();
-            console.log(ex);
-        }
-
-    };
-
-    BaseFacet.prototype.resetPreview = function(target) {
-        var preview = target.data("preview");
-        if (preview) {
-            preview.dispose();
-            target.data("preview", null);
-        }
-        target.empty();
-    };
 
     BaseFacet.prototype.showEditor = function(template){
         var model = this;
@@ -105,13 +80,19 @@ define(["jquery",
         });
         template.bind(this.refreshEvent, function() {
             model.updatePreview(template.find(".widget-preview-body"), config);
+
+            if (model.errors.length == 0) {
+                template.find("#widget_save_button").removeAttr("disabled").removeClass("disabled");
+            } else {
+                template.find("#widget_save_button").attr("disabled", "disabled").addClass("disabled");
+            }
         });
         this.triggerChange(config, template);
     };
 
     BaseFacet.prototype._propertyRenderer = function(prop) {
         return "." + prop.getID();
-    }
+    };
 
     return BaseFacet;
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/logo.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/logo.js
@@ -6,11 +6,14 @@ define(["jquery", "handlebars", "display/facets/logo", "exhibit", "text!template
     Facet.prototype.template = Handlebars.compile(template_html);
     Facet.prototype.icon_class = "fa fa-picture-o fa-3x";
 
+    Facet.prototype.validate = function(config) {
+        this.errors = [];
+        if (!config.src || config.src.length == 0) {
+            this.errors.push("A source URL is required");
+        }
+        return this.errors == 0;
+    };
 
-    Facet.prototype.isValid = function(config) {
-        return (config.src && config.src.length > 0);
-    }
-            
     Facet.prototype.setupEditor = function(config, template) {
 
         function updateSlider() {
@@ -82,7 +85,7 @@ define(["jquery", "handlebars", "display/facets/logo", "exhibit", "text!template
 
     };
 
-    Facet.prototype.updatePreview = function(target, config) {
+    Facet.prototype.renderPreview = function(target, config) {
         var preview = config.src ? this.generateExhibitHTML(config) : "";
         target.empty().append(preview);
     };

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/search.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/search.js
@@ -3,7 +3,7 @@ define(["jquery", "handlebars", "display/facets/search", "exhibit",
         function ($, Handlebars, Facet, Exhibit, template_html) {
         "use strict"
 
-    Facet.prototype.facetClass = Exhibit.TextSearchFacet;
+    Facet.prototype.exhibitClass = Exhibit.TextSearchFacet;
     Facet.prototype.icon_class = "fa fa-search fa-3x";
 
     Facet.prototype.label = "Search";

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/slider.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/slider.js
@@ -3,7 +3,7 @@ define(["jquery", "handlebars", "display/facets/slider", "exhibit",
         function ($, Handlebars, Facet, Exhibit, template_html) {
         "use strict"
 
-    Facet.prototype.facetClass = Exhibit.SliderFacet;
+    Facet.prototype.exhibitClass = Exhibit.SliderFacet;
     Facet.prototype.propertyTypes = ["number", "currency"];
 
     Facet.prototype.icon_class = "fa fa-trello fa-3x";
@@ -14,7 +14,7 @@ define(["jquery", "handlebars", "display/facets/slider", "exhibit",
     Facet.prototype.setupEditor = function(config, template) {
         var facet = this;
         var property = template.find("#facet_property");
-        this._setupPropertySelect(config, template, property, "expression", this.propertyTypes);
+        this._setupPropertySelect(config, template, property, "expression", this.propertyTypes, false, true);
         property.change();
 
         var label = template.find("#facet_name");
@@ -23,6 +23,14 @@ define(["jquery", "handlebars", "display/facets/slider", "exhibit",
           config.name = label.val();
           facet.triggerChange(config, template);
         });
+    };
+
+    Facet.prototype.validate = function(config) {
+        this.errors = [];
+        if (!config.expression) {
+            this.errors.push("This widget requires a property with a type of 'number'");
+        }
+        return this.errors.length == 0;
     };
 
     return Facet;

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/tagcloud.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/tagcloud.js
@@ -3,7 +3,7 @@ define(["jquery", "handlebars", "display/facets/tagcloud", "exhibit",
         function ($, Handlebars, Facet, Exhibit, template_html) {
         "use strict"
 
-    Facet.prototype.facetClass = Exhibit.CloudFacet;
+    Facet.prototype.exhibitClass = Exhibit.CloudFacet;
     Facet.prototype.propertyTypes = ["date", "number", "text", "currency"];
 
     Facet.prototype.icon_class = "fa fa-tags fa-3x";

--- a/viewshare/apps/exhibit/static/freemix/js/layout/facets/text.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/facets/text.js
@@ -30,7 +30,7 @@ define(["jquery",
             });
     };
 
-    Facet.prototype.updatePreview = function(target, config) {
+    Facet.prototype.renderPreview = function(target, config) {
         config = config || this.config;
         target.empty().creole(config.text);
     };

--- a/viewshare/apps/exhibit/static/freemix/js/layout/lenses/list.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/lenses/list.js
@@ -18,7 +18,7 @@ define(["jquery", "handlebars", "display/lenses/list",
         this._setupTitlePropertyEditor(config);
         var property_list = this.getEditor().find("#property_list");
         this._setupPropertyMultiSelect(config, this._editor, property_list, "properties", true);
-        property_list.change();
+        this._multiselect.onChange(null, null);
     };
 
     return Lens;

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/barchart.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/barchart.js
@@ -9,7 +9,7 @@ define(["jquery",
     View.prototype.label = "Bar Chart";
     View.prototype.icon_class = "fa fa-bar-chart-o fa-3x";
 
-    View.prototype.viewClass = BarChartView;
+    View.prototype.exhibitClass = BarChartView;
     View.prototype.template = Handlebars.compile(template_html);
 
     // Display the view's UI.

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/base.js
@@ -7,14 +7,15 @@ define(["jquery",
         "freemix/js/freemix",
         "text!templates/layout/view-widget.html",
         "text!templates/layout/view-menu.html"
-], function($, Exhibit, BaseView, LensRegistry, ViewRegistry, WidgetEditor, Freemix, widget_template, menu_template) {
+], function($, Exhibit, BaseView, LensRegistry, ViewRegistry,
+            WidgetEditor, Freemix, widget_template, menu_template) {
     "use strict"
 
     BaseView.prototype.refreshEvent = "refresh-preview.view";
 
     BaseView.prototype.propertyTypes = ["text", "image", "currency", "url", "location", "date", "number"];
 
-    BaseView.prototype.viewClass = Exhibit.TileView;
+    BaseView.prototype.exhibitClass = Exhibit.TileView;
 
     BaseView.prototype.showEditor = function(template) {
         var model = this;
@@ -35,15 +36,21 @@ define(["jquery",
 
             model.findWidget().find("span.view-label").text(model.config.name);
             model.select();
-           
+
         });
 
         template.bind(this.refreshEvent, function() {
             model.updatePreview(template.find(".widget-preview-body"), config);
+
+            if (model.errors.length == 0) {
+                template.find("#widget_save_button").removeAttr("disabled").removeClass("disabled");
+            } else {
+                template.find("#widget_save_button").attr("disabled", "disabled").addClass("disabled");
+            }
         });
 
         this.triggerChange(config, template);
-        
+
     };
 
     BaseView.prototype.getContainer = function() {
@@ -131,30 +138,6 @@ define(["jquery",
         }
     };
 
-    BaseView.prototype.updatePreview = function(target, config) {
-        config = config || this.config;
-        this.resetPreview(target);
-        var preview = this.generateExhibitHTML(config);
-        target.append(preview);
-        var exhibit = Freemix.getBuilderExhibit();
-
-        try {
-            target.data("preview", this.viewClass.createFromDOM(preview.get(0), null, exhibit.getUIContext()));
-        } catch(ex) {
-            target.empty();
-            console.log(ex);
-        }
-    };
-
-    BaseView.prototype.resetPreview = function(target) {
-        var preview = target.data("preview");
-        if (preview) {
-            preview.dispose();
-            target.data("preview", null);
-        }
-        target.empty();
-    };
-
     BaseView.prototype.display = function() {};
 
     BaseView.prototype.setupEditor = function(config, template) {};
@@ -174,8 +157,6 @@ define(["jquery",
             view.triggerChange(config, template);
         });
     };
-
-
 
     BaseView.prototype._setupMultiPropertySortEditor = function(config, template) {
         var sort = template.find("#sort_property");

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/list.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/list.js
@@ -7,7 +7,7 @@ define(["jquery",
         "use strict"
     View.prototype.icon_class = "fa fa-list fa-3x";
     View.prototype.label = "List";
-    View.prototype.viewClass = TileView;
+    View.prototype.exhibitClass = TileView;
     View.prototype.template = Handlebars.compile(template_html);
 
     View.prototype.setupEditor = function(config, template) {

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/map.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/map.js
@@ -48,7 +48,7 @@ define(["jquery",
 
     View.prototype.icon_class = "fa fa-globe fa-3x";
 
-    View.prototype.viewClass = OLMapView;
+    View.prototype.exhibitClass = OLMapView;
 
     View.prototype.template = Handlebars.compile(template_html);
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/piechart.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/piechart.js
@@ -9,7 +9,7 @@ define(["jquery",
     View.prototype.label = "Pie Chart";
     View.prototype.icon_class = "fa fa-adjust fa-3x";
 
-    View.prototype.viewClass = PiechartView;
+    View.prototype.exhibitClass = PiechartView;
     View.prototype.template = Handlebars.compile(template_html);
 
     // Display the view's UI.

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/scatterplot.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/scatterplot.js
@@ -11,7 +11,7 @@ define(["jquery",
     View.prototype.label = "Scatter Plot";
     View.prototype.icon_class = "fa fa-building-o fa-rotate-90 fa-3x";
 
-    View.prototype.viewClass = ScatterPlotView;
+    View.prototype.exhibitClass = ScatterPlotView;
 
     View.prototype.template = Handlebars.compile(template_html);
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/table.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/table.js
@@ -7,9 +7,19 @@ define(["jquery",
         "use strict"
 
     View.prototype.label = "Table";
-    View.prototype.viewClass = TabularView;
+    View.prototype.exhibitClass = TabularView;
     View.prototype.template = Handlebars.compile(template_html);
     View.prototype.icon_class = "fa fa-table fa-3x";
+
+    View.prototype.validate = function(config) {
+        this.errors = [];
+
+        if (config.properties.length == 0) {
+            this.errors.push("Please select properties to display");
+        }
+
+        return this.errors == 0;
+    };
 
     View.prototype.setupEditor = function (config, template) {
         var view = this;
@@ -32,9 +42,10 @@ define(["jquery",
         var property_list = template.find("#property_list");
         this._setupPropertyMultiSelect(config, template, property_list, "properties", true);
 
+        this._multiselect.onChange(null, null);
+
         sort.change();
         sort_order.change();
-        property_list.change();
     };
     return View;
 });

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/thumbnail.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/thumbnail.js
@@ -10,7 +10,7 @@ define(["jquery",
     View.prototype.propertyTypes = ["image"];
     View.prototype.icon_class = "fa fa-camera-retro fa-3x";
 
-    View.prototype.viewClass = ThumbnailView;
+    View.prototype.exhibitClass = ThumbnailView;
     View.prototype.template = Handlebars.compile(template_html);
 
     View.prototype._setupTitlePropertyEditor = function(config, template) {

--- a/viewshare/apps/exhibit/static/freemix/js/layout/views/timeline.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/views/timeline.js
@@ -44,7 +44,7 @@ define(["jquery",
 
     View.prototype.label = "Timeline";
     View.prototype.propertyTypes = ["date"];
-    View.prototype.viewClass = TimelineView;
+    View.prototype.exhibitClass = TimelineView;
     View.prototype.template = Handlebars.compile(template_html);
     View.prototype.icon_class = "fa fa-align-center fa-3x";
 

--- a/viewshare/apps/exhibit/static/freemix/js/layout/widget.js
+++ b/viewshare/apps/exhibit/static/freemix/js/layout/widget.js
@@ -1,18 +1,25 @@
-define(["jquery",
+define(["handlebars",
+        "jquery",
         "freemix/js/widget",
         "freemix/js/freemix",
         "multiselect",
+        "text!templates/layout/widget-errors.html",
         "freemix/js/exhibit_utilities",
         "layout/patch_exhibit"],
-function ($, Widget, Freemix, Multiselect) {
+function (Handlebars, $, Widget, Freemix, Multiselect, widget_errors) {
     "use strict";
+
+    var error_template = Handlebars.compile(widget_errors);
 
     function make_option(property_name) {
         return Freemix.exhibit.database.getProperty(property_name);
     }
 
+    Widget.prototype.exhibitClass = null;
+    Widget.prototype.errors = null;
+
     Widget.prototype._setupPropertySelect = function(config, template, selector, key, types, nullable, exclude_other_types) {
-        this._populatePropertySelect(selector, types, nullable);
+        this._populatePropertySelect(selector, types, nullable, exclude_other_types);
         this._setupSelectPropertyHandler(config, template, selector, key);
     };
 
@@ -28,7 +35,7 @@ function ($, Widget, Freemix, Multiselect) {
 
         var result = {
             order: []
-        }
+        };
         if ((types ||[]).length == 0) {
             types = this.propertyTypes;
         }
@@ -44,7 +51,6 @@ function ($, Widget, Freemix, Multiselect) {
                 result["order"].push(type);
             }
         }
-
         var filtered = database.getPropertyObjects(database.getFilteredProperties(filter));
         filtered.sort(sorter);
         result["others"] = filtered;
@@ -53,7 +59,7 @@ function ($, Widget, Freemix, Multiselect) {
 
     Widget.prototype._propertyRenderer = function(prop) {
         return prop.getID();
-    }
+    };
 
     Widget.prototype._buildOptionGroup = function(label, properties) {
         var optgroup = $("<optgroup>");
@@ -66,16 +72,16 @@ function ($, Widget, Freemix, Multiselect) {
             optgroup.append(option);
         }
         return optgroup;
-    }
+    };
 
-    Widget.prototype._populatePropertySelect = function(selector, types, nullable) {
+    Widget.prototype._populatePropertySelect = function(selector, types, nullable, exclude_others) {
         var properties = this._generatePropertyList(types);
         for (var inx = 0 ; inx < properties.order.length ; inx++) {
             var type = properties.order[inx];
             selector.append(this._buildOptionGroup(type + " properties", properties[type]));
         }
 
-        if (properties.others.length > 0) {
+        if (!exclude_others && properties.others.length > 0) {
             selector.append(this._buildOptionGroup("other properties", properties.others));
         }
         if (nullable) {
@@ -108,7 +114,7 @@ function ($, Widget, Freemix, Multiselect) {
         var value = config[key] || [];
         var selected = [];
         var deselected = [];
-        var inx, default_all;
+        var inx;
 
         if (value.length > 0) {
             default_all = false;
@@ -162,19 +168,54 @@ function ($, Widget, Freemix, Multiselect) {
         this.findWidget().remove();
     };
 
-    Widget.prototype.triggerChange = function(config, template) {
-        if (this.isValid(config)) {
-            template.find("#widget_save_button").removeAttr("disabled").removeClass("disabled");
 
-        } else {
-            template.find("#widget_save_button").attr("disabled", "disabled").addClass("disabled");
+    Widget.prototype.updatePreview = function(target, config) {
+        config = config || this.config;
+        this.resetPreview(target);
+
+        this.validate(config);
+
+        if (this.errors.length == 0) {
+            this.renderPreview(target, config);
         }
-        template.trigger(this.refreshEvent);
-    }
 
-    Widget.prototype.isValid = function() {
-        return true;
-    }
+        if (this.errors.length > 0) {
+            target.empty().append(error_template(this));
+        }
+    };
+
+    Widget.prototype.renderPreview = function(target, config) {
+        var preview = this.generateExhibitHTML(config);
+        target.append(preview);
+        var exhibit = Freemix.getBuilderExhibit();
+
+        try {
+            target.data("preview", this.exhibitClass.createFromDOM(preview.get(0), null, exhibit.getUIContext()));
+        } catch(ex) {
+            this.errors.push("Invalid Configuration");
+        }
+    };
+
+
+    Widget.prototype.resetPreview = function(target) {
+        var preview = target.data("preview");
+        if (preview) {
+            preview.dispose();
+            target.data("preview", null);
+        }
+        target.empty();
+    };
+
+
+    Widget.prototype.triggerChange = function(config, template) {
+        template.trigger(this.refreshEvent);
+    };
+
+    Widget.prototype.validate = function(config) {
+        this.errors = [];
+
+        return this.errors.length == 0;
+    };
 
     Widget.prototype.propertyTypes = ["text", "image", "currency", "url", "location", "date", "number"];
 

--- a/viewshare/apps/exhibit/static/freemix/js/templates/layout/widget-errors.html
+++ b/viewshare/apps/exhibit/static/freemix/js/templates/layout/widget-errors.html
@@ -1,0 +1,8 @@
+<div>
+  <h3>Validation</h3>
+  <ul>
+  {{#errors}}
+    <li class="text-error">{{ this }}</li>
+  {{/errors}}
+  </ul>
+</div>


### PR DESCRIPTION
This fixes the issue with table views not being initialized property (#125). The issue turned out to be a combination of the new property multiselect widget not initializing the property list when it comes in empty, and a secondary issue with the wrong change event being fired on the multiselect.

In the process of tracking this down, I modified the rudimentary (true/false) validation method to cache an array of error messages. If a particular view/facet fails to validate, these error messages are now rendered to the preview pane in lieu of the exhibit itself. In addition, the save button is disabled for the view editor. The error messages are terrible, but they're better than the blank pane you saw previously. Currently, there are four widgets with explicit validation: The Table view, the slider widget, the numeric widget, and the logo widget. If the widget validates but the preview render generates an exception, you see an 'Invalid Configuration' message. You can easily see this in action by selecting a timeline view and picking any property without a date value.

Since the exhibit numeric facet expects values explicitly typed as numbers, I modified the property selection list for this to only show number properties.
