### PR TITLE
Display array values properly in dataset editor

### DIFF
--- a/viewshare/apps/exhibit/static/dataset/js/templates/editor/property.html
+++ b/viewshare/apps/exhibit/static/dataset/js/templates/editor/property.html
@@ -19,13 +19,4 @@
   </select>
 </td>
 <td class="value">
-  {{#if selectedType.url}}
-    <a href="{{ value }}">{{ value }}</a>
-  {{else}}
-    {{#if selectedType.image}}
-      <img src="{{ value }}" style="height: 50px" />
-    {{else}}
-      {{ value }}
-    {{/if}}
-  {{/if}}
 </td>


### PR DESCRIPTION
This fixes #121. It's a general re-write of the way properties are rendered, so also adds audio and video rendering for symmetry with the builder.

In addition, records without any data for a particular property display 'No value' in a fashion similar to the old dataset editor.
