### PR TITLE
Adding redirects and changes to links on front page.

### DIFF
--- a/viewshare/templates/about/screencast.html
+++ b/viewshare/templates/about/screencast.html
@@ -1,0 +1,29 @@
+{% extends "site_base.html" %}
+
+{% load i18n %}
+
+{% block head_title %}
+{% trans "Terms of Service" %}
+{% endblock %}
+
+{% block head_css %}
+{{block.super}}
+
+{% endblock %}
+
+{% block body %}
+
+<h1>ViewShare.org Screencast </h1>
+  <p><strong>Welcome to ViewShare.org  </strong><br/>
+    The screencast below was recorded using the previous version of Viewshare.
+    </p>
+
+<div style="text-align: center;">
+<video width="800" height="468" autoplay>
+  <source src="/media/cms_page_media/13/viewshare%20video2.mp4" type="video/mp4">
+Your browser does not support the video tag.
+</video>
+    </div>
+
+{% endblock %}
+

--- a/viewshare/templates/front_page.html
+++ b/viewshare/templates/front_page.html
@@ -64,12 +64,12 @@
 	  </a>
 	</div>
 	<div class="lead-link">
-	  <a href="/screencast" class="btn btn-large">
+	  <a href="/about/screencast" class="btn btn-large">
 	    <div id="second" class="linkblock">Watch Screencast</div>
 	  </a>
 	</div>
 	<div class="lead-link">
-	  <a href="http://recollection.zepheira.com/about/help/" class="btn btn-large">
+	  <a href="http://viewshare.uservoice.com/knowledgebase/articles/248044-getting-started" class="btn btn-large">
 	    <div id="third" class="linkblock">Get Started</div>
 	  </a>
 	</div>

--- a/viewshare/urls.py
+++ b/viewshare/urls.py
@@ -67,21 +67,45 @@ urlpatterns += patterns('',
         TemplateView.as_view(template_name="about/tos.html"),
         name="tos"),
 
+    url(r'^screencast$',
+        RedirectView.as_view(url="about/screencast"),
+        name="screencast_redirect"),
+
+    url(r'^about/screencast$',
+        TemplateView.as_view(template_name="about/screencast.html"),
+        name="screencast"),
+
     url(r'^about/community/$',
         RedirectView.as_view(url="http://viewshare.uservoice.com"),
         name="community"),
 
+      url(r'^about/community/phay-user-story/$',
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase/articles/238997-phay-user-story"),
+        name="phay-user-story"),
+
+    url(r'^about/community/dove-user-story/$',
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase/articles/239623-desegregation-of-virginia-education-dove-project"),
+        name="desegregation-of-virginia-education-dove-project"),
+
+    url(r'^about/community/bpl-user-story/$',
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase/articles/239606-the-brooklyn-collection-s-fulton-street-trade-card"),
+        name="the-brooklyn-collection-s-fulton-street-trade-card"),
+
     url(r'^about/help/$',
-        RedirectView.as_view(url="http://viewshare.uservoice.com"),
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase"),
         name="help"),
 
     url(r'^about/faq/$',
-        RedirectView.as_view(url="http://viewshare.uservoice.com"),
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase/articles/240426-faq"),
         name="faq"),
 
     url(r'^about/userguide/$',
         RedirectView.as_view(url="http://viewshare.uservoice.com"),
         name="userguide"),
+
+    url(r'^about/user-stories/$',
+        RedirectView.as_view(url="http://viewshare.uservoice.com/knowledgebase/articles/238378-overview-user-stories"),
+        name="user-stories"),
 
     url(r'^augment/patterns/$',
         RedirectView.as_view(url="http://viewshare.uservoice.com"),


### PR DESCRIPTION
This adds a number of redirects to the site-top URLs file to handle the user stories (and other former-CMS) links, an HTML5 video page with the old screencast, and fixes the front button for "Getting Started." This patch is deployed on the staging server. Please comment. 
