### PR TITLE
On augmentation failure in the dataset editor, delete it

### DIFF
--- a/viewshare/apps/exhibit/static/dataset/js/models/editor/composite-property.js
+++ b/viewshare/apps/exhibit/static/dataset/js/models/editor/composite-property.js
@@ -145,6 +145,7 @@ define([
         /** Failed while sending property attributes to the server */
         augmentDataFailure: function() {
             this.Observer('augmentDataFailure').publish(this);
+            this.deleteProperty();
         },
 
         /**


### PR DESCRIPTION
When property augmentation fails in the dataset editor, a dead property is left around. I had originally approached this by rewriting the dataset editor to use the exhibit database so that the augmentation process in the builder could be integrated. The builder process is basically a closed loop that doesn't allow the user to continue until a property is successfully created and augmented or they cancel in the process. In the process of doing this, I missed the blindingly obvious simple solution, which is to just delete the new property on failure and rely on the existing error message.

This fixes half of the problem with #113. The other side of it is running the appropriate augmentations when the dataset is refreshed.
